### PR TITLE
make sure the popover is opening on the screen that has the menubar

### DIFF
--- a/Popup/PanelController.m
+++ b/Popup/PanelController.m
@@ -165,7 +165,7 @@
 
 - (NSRect)statusRectForWindow:(NSWindow *)window
 {
-    NSRect screenRect = [[window screen] frame];
+    NSRect screenRect = [[[NSScreen screens] objectAtIndex:0] frame];
     NSRect statusRect = NSZeroRect;
     
     StatusItemView *statusItemView = nil;
@@ -192,7 +192,7 @@
 {
     NSWindow *panel = [self window];
     
-    NSRect screenRect = [[panel screen] frame];
+    NSRect screenRect = [[[NSScreen screens] objectAtIndex:0] frame];
     NSRect statusRect = [self statusRectForWindow:panel];
     
     NSRect panelRect = [panel frame];


### PR DESCRIPTION
previously, if an external display was connected and the menu bar was moved to that screen, and then the display was removed (bringing the menu bar back to the one screen), the popover would fly off the screen. this fixes that by getting an array of screens and using index 0, which is defined in apple's docs as always being the screen with the menu bar. 
